### PR TITLE
fix: add support for JSXSpreadAttribute

### DIFF
--- a/index.js
+++ b/index.js
@@ -86,6 +86,15 @@ var generator = Object.assign(
       var output = state.output
       output.write(node.value)
     },
+    // {...prop}
+    // {...prop.v}
+    // {...func()}
+    JSXSpreadAttribute: function JSXSpreadAttribute(node, state) {
+      var output = state.output
+      output.write(` {...`)
+      this[node.argument.type](node.argument, state)
+      output.write(`} `)
+    },
   },
   astring.defaultGenerator
 )

--- a/sample.jsx
+++ b/sample.jsx
@@ -2,13 +2,24 @@
 
 class Test {
   render() {
-    return <>
+    const obj = {
+      a: 1,
+    };
+    const funcObj=()=>{
+      return {
+        a:1
+      }
+    }
+    return (
+      <>
         <div foo="bar" foo:bar={bux}>
           This is a test.
           <Test.Name.Foo />
           {foo.map(() => "bar")}
           <p>Text</p>
+          <div {...obj} {...obj.a} {...funcObj()}/>
         </div>
-      </>;
+      </>
+    );
   }
 }

--- a/tap-snapshots/test.js.test.cjs
+++ b/tap-snapshots/test.js.test.cjs
@@ -8,12 +8,21 @@
 exports[`test.js TAP supports all JSX features > must match snapshot 1`] = `
 class Test {
   render() {
+    const obj = {
+      a: 1
+    };
+    const funcObj = () => {
+      return {
+        a: 1
+      };
+    };
     return <>
         <div foo="bar" foo:bar={bux}>
           This is a test.
           <Test.Name.Foo />
           {foo.map(() => "bar")}
           <p>Text</p>
+          <div {...obj}  {...obj.a}  {...funcObj()}  />
         </div>
       </>;
   }


### PR DESCRIPTION

Handles writing for `JSXSpreadAttribute` 

Handled Cases

Ex:
```
<div {...obj} {...obj.a} {...funcObj()}/>
```